### PR TITLE
use tag instead of raw commit ID for OpenSBI

### DIFF
--- a/master.xml
+++ b/master.xml
@@ -38,5 +38,5 @@
     <project name="projects_libs.git" path="projects/projects_libs"/>
     <project name="cakeml_libs.git" path="projects/cakeml_libs"/>
     <project remote="nicta" name="cogent" path="tools/cogent" revision="master"/>
-    <project name="opensbi" remote="opensbi" revision="234ed8e427f4d92903123199f6590d144e0d9351" path="tools/opensbi"/>
+    <project name="opensbi" remote="opensbi" revision="refs/tags/v0.9" path="tools/opensbi"/>
 </manifest>


### PR DESCRIPTION
Note that this PR is on top of https://github.com/seL4/camkes-manifest/pull/10 for practical reason. It might be possible to merge this alone, but locally things always got messy, so I recommend doing the other PR first for fix the repo quirk.